### PR TITLE
Use zsh variable HISTFILE as default for input_file

### DIFF
--- a/zsh_history_to_fish/command.py
+++ b/zsh_history_to_fish/command.py
@@ -59,7 +59,7 @@ def writer_factory(output_file, dry_run):
 @click.command(help=__description__)
 @click.version_option()
 @click.argument('input_file', type=click.Path(exists=True), required=False,
-                default=os.path.expanduser(ZSH_HISTORY_FILE))
+                default=os.path.expanduser(HISTFILE))
 @click.option('--output_file', '-o', type=click.Path(),
               default=os.path.expanduser(FISH_HISTORY_FILE),
               help='Optional output, will append to fish history by default')


### PR DESCRIPTION
This tool didn't pick up my custom history file without me supplying an extra argument. I thought I'd save the next person the trouble :)

zsh uses `$HISTFILE` to set a custom history file, not `$ZSH_HISTORY_FILE`. See [`zshbuiltins(1)`](https://linux.die.net/man/1/zshbuiltins)